### PR TITLE
Correctly handles saving and retreving different file types

### DIFF
--- a/server/middleware/filters.js
+++ b/server/middleware/filters.js
@@ -3,6 +3,11 @@ const Joi = require('joi')
 
 exports.save_filter = function(db, json) {
 
+    if(typeof json.access.project === 'undefined' && typeof json.access.document === 'undefined' && typeof json.access.group === 'undefined') {
+        console.log("none of these exist so we give an error here")
+        return {"error": "please specify a #project #document or #group"}
+    }
+
     if(json.attachments.length > 0) {
         fschema = Joi.object({
             id: Joi.number().required(),
@@ -100,6 +105,11 @@ exports.save_filter = function(db, json) {
 }
 
 exports.get_filter = function(db, json) {
+
+    if(typeof json.access.project === 'undefined' && typeof json.access.document === 'undefined' && typeof json.access.group === 'undefined') {
+        console.log("none of these exist so we give an error here")
+        return {"error": "please specify a #project #document or #group"}
+    }
     
 const fschema = Joi.object({
     id: Joi.number().required(),

--- a/server/middleware/helpers.js
+++ b/server/middleware/helpers.js
@@ -171,7 +171,7 @@ exports.makeBodyAttachments = function (receiverId, subject, message, attach, fi
     for (var i = 0; i < attach.length; i++) {
         str += ["--" + boundary,
         "--" + boundary,
-        `Content-Type: ${mimeType}; name=${filenames[i]}`,
+        `Content-Type: ${mimeType[i]}; name=${filenames[i]}`,
         `Content-Disposition: attachment; filename=${filenames[i]}`,
         "Content-Transfer-Encoding: base64" + "\n",
         `${attach[i]}`,

--- a/server/routes/parse_gmail.js
+++ b/server/routes/parse_gmail.js
@@ -7,6 +7,7 @@ const db = new Database('./server/database/beavdms.db')
 const dbfun = require('../middleware/create_db')
 const helpers = require('../middleware/helpers')
 const filters = require('../middleware/filters')
+// const { raw } = require("core-js/core/string")
 const router = express.Router()
 require('dotenv').config()
 
@@ -653,7 +654,9 @@ async function g_request(callback) {
                         // }
 
                         var fpath = await get_file_path.get(docID).Location
-                        replyMessage.docs[docName.Name + "#" + doc.doc[j]] = fs.readFileSync(fpath, { encoding: 'base64' })
+                        var extension = fpath.split('.').pop()
+                        var rawfile = fs.readFileSync(fpath, { encoding: 'base64' })
+                        replyMessage.docs[docName.Name + "#" + doc.doc[j] + "." + extension] = rawfile 
                         mimeTypes[j] = docName.MIMEType
                         // console.log(`doc.doc[j]: ${doc.doc[j]}\tdocID: ${docID}\tmimeTypes[j]: ${mimeTypes[j]}`)
                         //document names can be accessed as an array by Object.keys(replyMessage.docs)


### PR DESCRIPTION
Files are now saved into the filesystem with the correct extension and into the database with the correct MIME type. File will also be retrieved with the correct mime type. Gmail seems to append the correct extension to common filetypes like pdf and jpg but less common filetypes like python and tex are returned without an extension. The only way to correct this may be to return the files with the filesystem name instead of the database name. 