### PR TITLE
Instances of proj.project changed to proj.name for consistency

### DIFF
--- a/server/middleware/filters.js
+++ b/server/middleware/filters.js
@@ -125,7 +125,7 @@ const fschema = Joi.object({
                     doc: Joi.array().required().min(1).label("please provide at least one document (ex. DocYear-DocCode) in #document [REQUIRED FIELD]"),
                 }).unknown().optional(),
                 project: Joi.object().keys({
-                    project: Joi.array().items(Joi.string()).min(1).max(1).required().label("please provide only one project (ex. ProjName#Code) in #project [REQUIRED FIELD]"),
+                    name: Joi.array().items(Joi.string()).min(1).max(1).required().label("please provide only one project (ex. ProjName#Code) in #project [REQUIRED FIELD]"),
                 }).unknown().optional(),
                 group: Joi.object().keys({
                     name: Joi.array().required().min(1).label("please provide at least one group name in #groups [REQUIRED FIELD]"),

--- a/server/routes/parse_gmail.js
+++ b/server/routes/parse_gmail.js
@@ -598,7 +598,7 @@ async function g_request(callback) {
                     await post_send_msg(g_access.data.access_token, raw)
                 }
                 if (proj) {
-                    const projNameCode = proj.project[0].split("#")
+                    const projNameCode = proj.name[0].split("#")
                     const projName = projNameCode[0]
                     const projCode = projNameCode[1] ? projNameCode[1] : "0001"
                     const projID = db.prepare(`SELECT ProjID FROM Projects WHERE Name = ? AND ProjectCode = ?`).get(projName, projCode)?.ProjID


### PR DESCRIPTION
I noticed that in most cases the names of projects were accessed as proj.name but in the case of get #project and the joi validation for get #project it was being accessed with proj.project. I changed both of these to access proj.name instead for the sake of consistency. 